### PR TITLE
Model plain_map/1 functions

### DIFF
--- a/lib/momo/maps.ex
+++ b/lib/momo/maps.ex
@@ -1,28 +1,9 @@
 defmodule Momo.Maps do
   @moduledoc false
 
-  @doc """
-  Converts a struct, map or keyword list into a plain map
-  """
-  def plain_map(data) when is_struct(data), do: Map.from_struct(data)
-  def plain_map(data) when is_map(data), do: data
-  def plain_map(data) when is_list(data), do: Map.new(data)
+  alias Momo.Maps.Plain
+  alias Momo.Maps.StringKeys
 
-  def string_keys(%Date{} = date), do: date
-  def string_keys(%DateTime{} = datetime), do: datetime
-
-  def string_keys(list) when is_list(list) do
-    Enum.map(list, &string_keys/1)
-  end
-
-  def string_keys(map) when is_map(map) do
-    map
-    |> plain_map()
-    |> Enum.map(fn {key, value} -> {to_string(key), string_keys(value)} end)
-    |> Enum.into(%{})
-  end
-
-  def string_keys(value) do
-    value
-  end
+  defdelegate plain_map(data), to: Plain, as: :to_plain_map
+  defdelegate string_keys(data), to: StringKeys, as: :to_string_keys
 end

--- a/lib/momo/maps/plain.ex
+++ b/lib/momo/maps/plain.ex
@@ -1,0 +1,32 @@
+defprotocol Momo.Maps.Plain do
+  @fallback_to_any true
+  def to_plain_map(data)
+end
+
+defimpl Momo.Maps.Plain, for: Map do
+  def to_plain_map(map), do: map
+end
+
+defimpl Momo.Maps.Plain, for: List do
+  def to_plain_map(list) do
+    if Keyword.keyword?(list), do: Map.new(list), else: list
+  end
+end
+
+defimpl Momo.Maps.Plain, for: Ecto.Association.NotLoaded do
+  def to_plain_map(_), do: nil
+end
+
+defimpl Momo.Maps.Plain, for: Any do
+  def to_plain_map(data) when is_struct(data) do
+    data
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+    |> Enum.reject(fn {_k, v} ->
+      match?(%Ecto.Association.NotLoaded{}, v)
+    end)
+    |> Enum.into(%{})
+  end
+
+  def to_plain_map(data), do: data
+end

--- a/lib/momo/maps/string_keys.ex
+++ b/lib/momo/maps/string_keys.ex
@@ -1,0 +1,49 @@
+defprotocol Momo.Maps.StringKeys do
+  @fallback_to_any true
+  def to_string_keys(data)
+end
+
+defimpl Momo.Maps.StringKeys, for: [Date, DateTime, NaiveDateTime, Time] do
+  def to_string_keys(data), do: data
+end
+
+defimpl Momo.Maps.StringKeys, for: List do
+  def to_string_keys(list) do
+    Enum.map(list, &Momo.Maps.StringKeys.to_string_keys/1)
+  end
+end
+
+defimpl Momo.Maps.StringKeys, for: Map do
+  def to_string_keys(map) do
+    case Momo.Maps.Plain.to_plain_map(map) do
+      nil ->
+        nil
+
+      plain_map when is_map(plain_map) ->
+        plain_map
+        |> Enum.map(fn {key, value} ->
+          {to_string(key), Momo.Maps.StringKeys.to_string_keys(value)}
+        end)
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Enum.into(%{})
+
+      other ->
+        Momo.Maps.StringKeys.to_string_keys(other)
+    end
+  end
+end
+
+defimpl Momo.Maps.StringKeys, for: Ecto.Association.NotLoaded do
+  def to_string_keys(_), do: nil
+end
+
+defimpl Momo.Maps.StringKeys, for: Any do
+  def to_string_keys(data) when is_struct(data) do
+    case Momo.Maps.Plain.to_plain_map(data) do
+      nil -> nil
+      plain_data -> Momo.Maps.StringKeys.to_string_keys(plain_data)
+    end
+  end
+
+  def to_string_keys(data), do: data
+end

--- a/lib/momo/model.ex
+++ b/lib/momo/model.ex
@@ -18,7 +18,8 @@ defmodule Momo.Model do
       Momo.Model.Generator.EditFunction,
       Momo.Model.Generator.DeleteFunction,
       Momo.Model.Generator.ListFunction,
-      Momo.Model.Generator.Query
+      Momo.Model.Generator.Query,
+      Momo.Model.Generator.PlainMap
     ]
 
   defstruct [

--- a/lib/momo/model/generator/plain_map.ex
+++ b/lib/momo/model/generator/plain_map.ex
@@ -1,0 +1,11 @@
+defmodule Momo.Model.Generator.PlainMap do
+  @moduledoc false
+
+  @behaviour Diesel.Generator
+  def generate(_model, _) do
+    quote do
+      def plain_map(%__MODULE__{} = model),
+        do: Momo.Maps.string_keys(model)
+    end
+  end
+end

--- a/test/momo/model_test.exs
+++ b/test/momo/model_test.exs
@@ -154,4 +154,20 @@ defmodule Momo.ModelTest do
       refute Ecto.assoc_loaded?(credential.user)
     end
   end
+
+  describe "plain_map/1" do
+    test "turns a model into a plain map with string keys" do
+      assert {:ok, user} =
+               Accounts.create_user(email: "foo@bar", external_id: uuid(), public: true)
+
+      assert %{
+               "email" => user.email,
+               "external_id" => user.external_id,
+               "id" => user.id,
+               "inserted_at" => user.inserted_at,
+               "public" => user.public,
+               "updated_at" => user.updated_at
+             } == User.plain_map(user)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Adds a new `plain_map/1` function to models that converts them into plain maps with string values. This is a convenience function so that we can then prepare these models to be displayed in UI views. 