### PR TITLE
Emit one event per item returned by a comman

### DIFF
--- a/lib/momo/command/dsl/command.ex
+++ b/lib/momo/command/dsl/command.ex
@@ -5,6 +5,7 @@ defmodule Momo.Command.Dsl.Command do
   tag do
     attribute :params, kind: :module, required: true
     attribute :returns, kind: :module, required: false
+    attribute :many, kind: :boolean, required: false, default: false
     attribute :atomic, kind: :boolean, required: false, default: false
     attribute :title, kind: :string, required: false
 

--- a/lib/momo/command/parser.ex
+++ b/lib/momo/command/parser.ex
@@ -70,6 +70,8 @@ defmodule Momo.Command.Parser do
       |> Macro.underscore()
       |> String.to_atom()
 
+    many = Keyword.get(attrs, :many, false)
+
     %Command{
       name: name,
       title: title,
@@ -77,6 +79,7 @@ defmodule Momo.Command.Parser do
       feature: feature,
       params: params,
       returns: returns,
+      many: many,
       policies: policies,
       atomic?: atomic?,
       events: events

--- a/lib/momo/feature.ex
+++ b/lib/momo/feature.ex
@@ -30,7 +30,8 @@ defmodule Momo.Feature do
     events: [],
     flows: [],
     subscriptions: [],
-    values: []
+    values: [],
+    mappings: []
   ]
 
   require Logger

--- a/lib/momo/feature/parser.ex
+++ b/lib/momo/feature/parser.ex
@@ -23,6 +23,7 @@ defmodule Momo.Feature.Parser do
     |> with_modules(children, :subscriptions)
     |> with_modules(children, :mappings)
     |> with_modules(children, :values)
+    |> ensure_command_event_compatibility!()
   end
 
   defp with_modules(feature, children, kind) do
@@ -30,5 +31,23 @@ defmodule Momo.Feature.Parser do
     mods = List.flatten(mods)
 
     Map.put(feature, kind, mods)
+  end
+
+  defp ensure_command_event_compatibility!(feature) do
+    for command <- feature.commands, event <- command.events() do
+      event_module = event.module
+      input = Enum.find(feature.mappings, &(&1 == event.mapping)) || command.returns()
+      input_fields = with fields when is_map(fields) <- input.fields(), do: Map.values(fields)
+
+      for field when field.required <- event_module.fields() do
+        if input_fields |> Enum.find(&(&1.name == field.name)) |> is_nil() do
+          raise """
+          Event #{inspect(event_module)} cannot be mapped from the output of command #{inspect(command)} because field #{inspect(field.name)} does not exist in #{inspect(input)}.
+          """
+        end
+      end
+    end
+
+    feature
   end
 end

--- a/lib/momo/job.ex
+++ b/lib/momo/job.ex
@@ -21,7 +21,7 @@ defmodule Momo.Job do
     event = Module.concat([event])
 
     with {:ok, event} <- event.decode(params),
-         {:ok, _} <- subscription.execute(event) do
+         :ok <- execute_subscription(subscription, event) do
       handle_success(subscription: subscription)
     else
       {:error, reason} ->
@@ -54,6 +54,14 @@ defmodule Momo.Job do
     e ->
       reason = Exception.format(:error, e, __STACKTRACE__)
       handle_error(job, reason, command: command, flow: flow)
+  end
+
+  defp execute_subscription(subscription, event) do
+    case subscription.execute(event) do
+      :ok -> :ok
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
   end
 
   defp handle_error(job, reason, meta) do

--- a/lib/momo/query.ex
+++ b/lib/momo/query.ex
@@ -97,7 +97,7 @@ defmodule Momo.Query do
   Executes the query with the given parameters and context
   """
   def execute(query, params, context) do
-    params = Map.new(params)
+    params = params(params)
 
     with {:ok, params} <- query.params().validate(params),
          context <- Map.put(context, :params, params) do
@@ -136,6 +136,10 @@ defmodule Momo.Query do
       |> call_repo(query, context)
     end
   end
+
+  defp params(params) when is_struct(params), do: Map.from_struct(params)
+  defp params(params) when is_list(params), do: Map.new(params)
+  defp params(params) when is_map(params), do: params
 
   defp call_repo(queriable, query, _context) do
     repo = query.feature().repo()

--- a/test/momo/command_test.exs
+++ b/test/momo/command_test.exs
@@ -1,7 +1,7 @@
 defmodule Momo.CommandTest do
   use Momo.DataCase
 
-  alias Blogs.Accounts.Commands.{RemindPassword, RegisterUser}
+  alias Blogs.Accounts.Commands.{ExpireCredentials, RemindPassword, RegisterUser}
   alias Blogs.Accounts.User
   alias Blogs.Accounts.Values.UserId
   alias Blogs.Accounts.Events.UserRegistered
@@ -66,6 +66,15 @@ defmodule Momo.CommandTest do
       assert {:ok, result, events} = RemindPassword.execute(params, context)
       assert result == params
       assert events == []
+    end
+
+    test "returns one event per item returned" do
+      params = %UserId{user_id: uuid()}
+      context = %{}
+
+      assert {:ok, credentials, events} = ExpireCredentials.execute(params, context)
+      assert 2 == length(credentials)
+      assert 2 == length(events)
     end
   end
 end

--- a/test/support/blogs/accounts.ex
+++ b/test/support/blogs/accounts.ex
@@ -10,6 +10,7 @@ defmodule Blogs.Accounts do
     end
 
     commands do
+      Blogs.Accounts.Commands.ExpireCredentials
       Blogs.Accounts.Commands.RegisterUser
       Blogs.Accounts.Commands.RemindPassword
       Blogs.Accounts.Commands.EnableUser
@@ -30,9 +31,11 @@ defmodule Blogs.Accounts do
     end
 
     events do
-      Blogs.Accounts.Events.UserRegistered
+      Blogs.Accounts.Events.CredentialsExpired
       Blogs.Accounts.Events.PasswordRemindedSent
       Blogs.Accounts.Events.UserOnboarded
+      Blogs.Accounts.Events.UserRegistered
+      Blogs.Accounts.Events.UsersLocked
     end
 
     flows do

--- a/test/support/blogs/accounts/commands/expire_credentials.ex
+++ b/test/support/blogs/accounts/commands/expire_credentials.ex
@@ -1,0 +1,35 @@
+defmodule Blogs.Accounts.Commands.ExpireCredentials do
+  @moduledoc false
+  use Momo.Command
+
+  alias Blogs.Accounts.Values.UserId
+  alias Blogs.Accounts.Credential
+  alias Blogs.Accounts.Events.CredentialExpired
+
+  command params: UserId, returns: Credential, many: true do
+    publish event: CredentialExpired
+  end
+
+  def handle(params, _context) do
+    credentials = [
+      %Credential{
+        id: Ecto.UUID.generate(),
+        user_id: params.user_id,
+        name: "password",
+        type: 1,
+        value: "password123",
+        enabled: true
+      },
+      %Credential{
+        id: Ecto.UUID.generate(),
+        user_id: params.user_id,
+        name: "pin",
+        type: 2,
+        value: "1234",
+        enabled: true
+      }
+    ]
+
+    {:ok, credentials}
+  end
+end

--- a/test/support/blogs/accounts/events/credential_expired.ex
+++ b/test/support/blogs/accounts/events/credential_expired.ex
@@ -1,0 +1,11 @@
+defmodule Blogs.Accounts.Events.CredentialExpired do
+  @moduledoc false
+
+  use Momo.Event
+
+  event do
+    field :user_id, type: :id
+    field :type, type: :integer
+    field :foo, type: :string
+  end
+end


### PR DESCRIPTION
# Description

Commands can return multiple items. Now, by default, the declared event will be published for every single item. 